### PR TITLE
implement prompt:none flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,14 @@ def healthz():
     return jsonify({'status': 'ok'})
 
 
+@app.route('/logout')
+def logout():
+    if 'subject' in flask_session:
+        del flask_session['subject']
+        return jsonify({'message': 'logged out'})
+    return jsonify({'message': 'no user logged in'})
+
+
 @app.route('/consent', methods=['GET'])
 def consent_get():
     session = get_session()

--- a/app.py
+++ b/app.py
@@ -43,6 +43,21 @@ def logout():
 
 @app.route('/consent', methods=['GET'])
 def consent_get():
+    # Handle GET-requests to the consent endpoint. These are initiated when the
+    # User Agent (UA) navigates to the token request URL and Hydra redirects them
+    # here. We are passed an id for the consent request in the query string
+    # which we should validate, examine and accept or reject as we see fit.
+    #
+    # If no user interaction is needed to accept/reject the request, we
+    # immediately do so and redirect the UA back to Hydra by means of the
+    # redirect URI Hydra gives us. No interaction is needed if the user is
+    # logged in or the "prompt:none" scope is requested and there is no current
+    # logged in user.
+    #
+    # If user interaction *is* needed, we render a simple login form which will
+    # POST its content back to the '/consent' endpoint. This is handled by
+    # consent_post() below.
+
     session = get_session()
 
     error = request.args.get('error')
@@ -78,6 +93,14 @@ def consent_get():
 
 @app.route('/consent', methods=['POST'])
 def consent_post():
+    # Handle POST requests to the consent endpoint. These are initiated after
+    # user interaction with the form rendered by consent_get(). The form
+    # provides us with the current Hydra consent id and the scheme and
+    # identifier for the user which should be logged in.
+    #
+    # We take the scheme and identifier from the form and use them to construct
+    # a subject for the consent request which we immediately grant.
+
     session = get_session()
 
     consent_id = request.args.get('consent')


### PR DESCRIPTION
Implement prompt:none flow to match that proposed in uisautomation/hydra-consent-app#5. This commit is intended to keep the mock consent app and real consent app in lock step with regards to features.

Update the app to cache the current subject in the flask session and automatically grant requests if there is a user in the session. This approximates the existing Raven behaviour.

Teach the app about the "prompt:none" scope which signals that the request should be immediately rejected if there is not a user in the session.

This PR is required by uisautomation/iar-frontend#153.

Closes #1